### PR TITLE
Feature/bag submit data cucumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.0.0",
     "jsum": "^2.0.0-alpha.4",
     "lodash": "^4.17.21",
+    "mustache": "^4.2.0",
     "winston": "^3.6.0"
   },
   "devDependencies": {

--- a/src/examples/testBlueprint.json
+++ b/src/examples/testBlueprint.json
@@ -24,7 +24,7 @@
       {
         "id": "CONFIG-TEST",
         "name": "CONFIG",
-        "next": "NOTIFY-TEST",
+        "next": "GENERATE-TOKEN-TEST",
         "type": "SystemTask",
         "category": "setToBag",
         "lane_id": "free",
@@ -38,26 +38,20 @@
         "nodeSpec": "configTest"
       },
       {
-        "id": "NOTIFY-TEST",
-        "name": "NOTIFY",
+        "id": "GENERATE-TOKEN-TEST",
+        "name": "Generate random token",
         "next": "COUNT-TEST",
-        "type": "UserTask",
-        "lane_id": "actorId",
+        "type": "SystemTask",
+        "category": "setToBag",
+        "lane_id": "free",
         "parameters": {
-          "input": {},
-          "action": "NOTIFY_USER",
-          "activity_manager": "commit",
-          "timeout": 30,
-          "activity_schema": {
-            "type": "object",
-            "additionalProperties": false
+          "input": {
+            "token": {
+              "$js": "() => `${Math.floor(1000 + Math.random() * 9000)}`"
+            }
           }
         },
-        "example": {
-          "file": "",
-          "schema": ""
-        },
-        "nodeSpec": "notifyTest"
+        "nodeSpec": "generateTokenTest"
       },
       {
         "id": "COUNT-TEST",
@@ -79,7 +73,7 @@
         "id": "CHECK-COUNT-TEST",
         "name": "Check if count is 3",
         "next": {
-            "3": "END-TEST",
+            "3": "CONFIRM-TOKEN-TEST",
             "default": "COUNT-TEST"
         },
         "type": "Flow",
@@ -94,7 +88,53 @@
         }
       },
       {
-        "id": "END-TEST",
+        "id": "CONFIRM-TOKEN-TEST",
+        "name": "Confirm generated token",
+        "next": "IS-TOKEN-VALID",
+        "type": "UserTask",
+        "lane_id": "actorId",
+        "parameters": {
+          "input": {},
+          "action": "CONFIRM_TOKEN",
+          "activity_manager": "commit",
+          "timeout": 30,
+          "activity_schema": {
+            "type": "object",
+            "properties": {
+              "token": {
+                "type": "string"
+              }
+            },
+            "required": [ "token" ],
+            "additionalProperties": false
+          }
+        },
+        "example": {
+          "file": "",
+          "schema": ""
+        },
+        "nodeSpec": "confirmTokenTest"
+      },
+      {
+        "id": "IS-TOKEN-VALID",
+        "name": "Check if token is valid",
+        "next": {
+            "true": "END-TEST-SUCCESS",
+            "default": "END-TEST-ERROR"
+        },
+        "type": "Flow",
+        "lane_id": "actorId",
+        "nodeSpec": "checkCountTest",
+        "parameters": {
+            "input": {
+                "key": {
+                    "$js": "({result, bag}) => (result.activities[0].data.token === bag.token)"
+                }
+            }
+        }
+      },
+      {
+        "id": "END-TEST-SUCCESS",
         "name": "end",
         "type": "Finish",
         "next": null,
@@ -102,7 +142,18 @@
         "parameters": {
           "input": {}
         },
-        "nodeSpec": "endTest"
+        "nodeSpec": "endTestSuccess"
+      },
+      {
+        "id": "END-TEST-ERROR",
+        "name": "end error",
+        "type": "Finish",
+        "next": null,
+        "lane_id": "actorId",
+        "parameters": {
+          "input": {}
+        },
+        "nodeSpec": "endTestError"
       }
     ],
     "lanes": [

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -39,8 +39,8 @@ Given(
   }
 );
 
-Then("the process passes through {string}", { timeout: 60 * 1000 }, async function (node) {
-  await wait(500);
+Then("the process passed through {string}", { timeout: 60 * 1000 }, async function (node) {
+  await this.waitProcessStop();
   await this.getProcessHistory();
   const nodeState = this.history.find(state => state.node_id === node);
   assert.equal(nodeState.node_id, node);
@@ -48,8 +48,8 @@ Then("the process passes through {string}", { timeout: 60 * 1000 }, async functi
   return;
 });
 
-Then("o processo passa pelo nó {string}", { timeout: 60 * 1000 }, async function (node) {
-  await wait(500);
+Then("o processo passou pelo nó {string}", { timeout: 60 * 1000 }, async function (node) {
+  await this.waitProcessStop();
   await this.getProcessHistory();
   const nodeState = this.history.find(state => state.node_id === node);
   assert.equal(nodeState.node_id, node);

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -89,6 +89,19 @@ Then("o processo passou pelo menos {int} vezes pelo nó {string}", { timeout: 60
   return;
 });
 
+Then("save the variable {string} with the value {string}", { timeout: 60 * 1000 }, async function (variable, property) {
+  await this.getProcessHistory();
+  await this.saveValue(variable, property);
+  return;
+});
+
+Then("salvo a variável {string} com o valor de {string}", { timeout: 60 * 1000 }, async function (variable, property) {
+  await this.getProcessHistory();
+  await this.saveValue(variable, property);
+  return;
+});
+
+
 When("the user submits {string}", { timeout: 60 * 1000 }, async function (payload) {
   await this.submitActivity(payload);
   return;

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -1,5 +1,12 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
 const assert = require("assert").strict;
+const actualTimeout = setTimeout;
+
+function wait(ms = 5000) {
+  return new Promise((resolve) => {
+    actualTimeout(resolve, ms);
+  });
+}
 
 Given("the default user is logged in", { timeout: 60 * 1000 }, async function () {
   await this.getToken();
@@ -40,6 +47,7 @@ Given(
 );
 
 Then("the process passes through {string}", { timeout: 60 * 1000 }, async function (node) {
+  await wait(500);
   await this.getProcessHistory();
   const nodeState = this.history.find(state => state.node_id === node);
   assert.equal(nodeState.node_id, node);
@@ -48,6 +56,7 @@ Then("the process passes through {string}", { timeout: 60 * 1000 }, async functi
 });
 
 Then("o processo passa pelo nó {string}", { timeout: 60 * 1000 }, async function (node) {
+  await wait(500);
   await this.getProcessHistory();
   const nodeState = this.history.find(state => state.node_id === node);
   assert.equal(nodeState.node_id, node);

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -80,7 +80,7 @@ Then("o processo passou {int} vezes pelo nó {string}", { timeout: 60 * 1000 }, 
   return;
 });
 
-Then("the process passed at least {int} times through {string}", { timeout: 60 * 1000 }, async function (node) {
+Then("the process passed at least {int} times through {string}", { timeout: 60 * 1000 }, async function (passTimes, node) {
   await this.waitProcessStop();
   await this.getProcessHistory();
   const nodeState = this.history.filter(state => state.node_id === node && state.status === "running");

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -1,12 +1,5 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
 const assert = require("assert").strict;
-const actualTimeout = setTimeout;
-
-function wait(ms = 5000) {
-  return new Promise((resolve) => {
-    actualTimeout(resolve, ms);
-  });
-}
 
 Given("the default user is logged in", { timeout: 60 * 1000 }, async function () {
   await this.getToken();
@@ -108,6 +101,7 @@ When("o usuário submete {string}", { timeout: 60 * 1000 }, async function (payl
 
 Then("the process waits at {string}", { timeout: 60 * 1000 }, async function (node) {
   await this.waitProcessStop();
+  await this.getCurrentActivity();
   assert.equal(this.currentStatus, "waiting");
   assert.equal(this.nodeId, node);
   return;
@@ -115,6 +109,7 @@ Then("the process waits at {string}", { timeout: 60 * 1000 }, async function (no
 
 Then("o processo para no nó {string}", { timeout: 60 * 1000 }, async function (node) {
   await this.waitProcessStop();
+  await this.getCurrentActivity();
   assert.equal(this.currentStatus, "waiting");
   assert.equal(this.nodeId, node);
   return;

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -91,10 +91,6 @@ class CustomWorld {
       await this.getCurrentState();
       logger.debug(`process status: ${this.currentStatus}`);
     } while (!expectedStatus.includes(this.currentStatus));
-
-    if (this.currentStatus === "waiting") {
-      await this.getCurrentActivity();
-    }
     return;
   }
 

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -50,7 +50,7 @@ class CustomWorld {
       url: `/workflows/name/${workflowName}/start`,
       baseURL: FLOWBUILD_URL,
       headers: { Authorization: `Bearer ${this.token}` },
-      data: initialBag,
+      data: JSON.parse(initialBag),
     });
     logger.debug("startProcess received");
     this.pid = response.data.process_id;

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -5,6 +5,8 @@ const { setWorldConstructor } = require("@cucumber/cucumber");
 const FLOWBUILD_URL = process.env.FLOWBUILD_URL;
 const actualTimeout = setTimeout;
 const mustache = require('mustache');
+const _ = require('lodash');
+let worldData = {};
 
 function wait(ms = 5000) {
   return new Promise((resolve) => {
@@ -133,6 +135,23 @@ class CustomWorld {
     });
     logger.debug(`getProcessHistory response ${response.status}`);
     this.history = response.data;
+    return;
+  }
+
+  async saveValue(variable, property) {
+    const nodeState = this.history[0];
+    const stateHasProperty = _.has(nodeState, property);
+    if(stateHasProperty) {
+      const worldHasProperty = _.has(worldData, variable);
+      if(!worldHasProperty) {
+        worldData[variable] = _.get(nodeState, property);
+        logger.info(`Variável ${variable} salva no World com o valor: ${worldData[variable]}`);
+        return;
+      }
+      logger.info(`World já possui a variável ${variable} salva com o valor: ${worldData[variable]}`);
+      return;
+    }
+    logger.info(`O processo não possui a propriedade ${property}`);
     return;
   }
 }

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -65,26 +65,16 @@ class CustomWorld {
       const nodeState = this.history.find(state => state.status === "waiting");
       const middlePayload = JSON.parse(mustache.render(payload, nodeState.bag));
       const payloadPairs = Object.entries(middlePayload).map(subArr => subArr.map(value => value.toString()));
-      const resultPayload = Object.fromEntries(payloadPairs);
-      const response = await axios({
-        method: "post",
-        url: `/activity_manager/${this.amid}/submit`,
-        baseURL: FLOWBUILD_URL,
-        headers: { Authorization: `Bearer ${this.token}` },
-        data: resultPayload,
-      });
-      logger.debug("submitActivity response");
-      if (response.status === 200) {
-        return true;
-      }
-      return false;
+      this.resultPayload = Object.fromEntries(payloadPairs);
+    } else {
+      this.resultPayload = JSON.parse(payload);
     }
     const response = await axios({
       method: "post",
       url: `/activity_manager/${this.amid}/submit`,
       baseURL: FLOWBUILD_URL,
       headers: { Authorization: `Bearer ${this.token}` },
-      data: JSON.parse(payload),
+      data: this.resultPayload,
     });
     logger.debug("submitActivity response");
     if (response.status === 200) {

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -6,7 +6,13 @@ const FLOWBUILD_URL = process.env.FLOWBUILD_URL;
 const actualTimeout = setTimeout;
 const mustache = require('mustache');
 const _ = require('lodash');
-let worldData = {};
+const fs = require('fs');
+if (!fs.existsSync("tests/features/support/worldData.json")) {
+  fs.writeFileSync("tests/features/support/worldData.json", "{}", (err) => {
+    if (err) throw err;
+  });
+}
+let worldData = require('./worldData.json');
 
 function wait(ms = 5000) {
   return new Promise((resolve) => {
@@ -144,10 +150,13 @@ class CustomWorld {
       const worldHasProperty = _.has(worldData, variable);
       if(!worldHasProperty) {
         worldData[variable] = _.get(nodeState, property);
-        logger.info(`Variável ${variable} salva no World com o valor: ${worldData[variable]}`);
+        fs.writeFileSync("tests/features/support/worldData.json", JSON.stringify(worldData), err => {
+          if (err) throw err;
+        });
+        logger.info(`Variável ${variable} salva no arquivo worldData.json com o valor: ${worldData[variable]}`);
         return;
       }
-      logger.info(`World já possui a variável ${variable} salva com o valor: ${worldData[variable]}`);
+      logger.info(`Arquivo worldData.json já possui a variável ${variable} salva com o valor: ${worldData[variable]}`);
       return;
     }
     logger.info(`O processo não possui a propriedade ${property}`);

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -64,8 +64,7 @@ class CustomWorld {
     logger.info(`submitActivity ${this.amid}`);
     if(payload.includes('{{')) {
       await this.getProcessHistory();
-      const nodeState = this.history.find(state => state.status === "waiting");
-      const middlePayload = JSON.parse(mustache.render(payload, nodeState.bag));
+      const middlePayload = JSON.parse(mustache.render(payload, worldData));
       const payloadPairs = Object.entries(middlePayload).map(subArr => subArr.map(value => value.toString()));
       this.resultPayload = Object.fromEntries(payloadPairs);
     } else {

--- a/tests/features/support/world.js
+++ b/tests/features/support/world.js
@@ -60,7 +60,6 @@ class CustomWorld {
 
   async submitActivity(payload) {
     logger.info(`submitActivity ${this.amid}`);
-    // const newPayload = payload.replaceAll('{{','"').replaceAll('}}','"');
     if(payload.includes('{{')) {
       await this.getProcessHistory();
       const nodeState = this.history.find(state => state.status === "waiting");

--- a/tests/features/testBlueprint.feature
+++ b/tests/features/testBlueprint.feature
@@ -5,18 +5,20 @@ Funcionalidade: testBlueprint
   Cenario: test happy path
     Dado que um usuario anonimo esta logado
     Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais '{}'
-    Então o processo passou pelo nó 'CONFIG-TEST'
+    Então o processo passou pelo nó 'GENERATE-TOKEN-TEST'
+    Então salvo a variável 'token' com o valor de 'bag.token'
     Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
     Quando o usuário submete '{ "token": {{token}} }'
     Entao o processo passou pelo menos 2 vezes pelo nó 'COUNT-TEST'
-    Entao o processo passou 3 vezes pelo nó 'CHECK-COUNT-TEST' 
+    Entao o processo passou 3 vezes pelo nó 'CHECK-COUNT-TEST'
     Entao o processo finaliza no nó 'END-TEST-SUCCESS'  
     
   @unhappy
   Cenario: test unhappy path
     Dado que um usuario anonimo esta logado
     Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais '{}'
-    Então o processo passou pelo nó 'CONFIG-TEST'
+    Então o processo passou pelo nó 'GENERATE-TOKEN-TEST'
+    Então salvo a variável 'token' com o valor de 'bag.token'
     Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
     Quando o usuário submete '{ "token": "123" }'
     Entao o processo passou pelo menos 2 vezes pelo nó 'COUNT-TEST'

--- a/tests/features/testBlueprint.feature
+++ b/tests/features/testBlueprint.feature
@@ -5,7 +5,7 @@ Funcionalidade: testBlueprint
   Cenario: test happy path
     Dado que um usuario anonimo esta logado
     Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais '{}'
-    Então o processo passa pelo nó 'CONFIG-TEST'
+    Então o processo passou pelo nó 'CONFIG-TEST'
     Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
     Quando o usuário submete '{ "token": {{token}} }'
     Entao o processo passou pelo menos 2 vezes pelo nó 'COUNT-TEST'
@@ -16,7 +16,7 @@ Funcionalidade: testBlueprint
   Cenario: test unhappy path
     Dado que um usuario anonimo esta logado
     Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais '{}'
-    Então o processo passa pelo nó 'CONFIG-TEST'
+    Então o processo passou pelo nó 'CONFIG-TEST'
     Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
     Quando o usuário submete '{ "token": "123" }'
     Entao o processo passou pelo menos 2 vezes pelo nó 'COUNT-TEST'

--- a/tests/features/testBlueprint.feature
+++ b/tests/features/testBlueprint.feature
@@ -2,12 +2,23 @@
 Funcionalidade: testBlueprint
 
   @happy
-  Cenario: test path
+  Cenario: test happy path
     Dado que um usuario anonimo esta logado
     Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais ''
     Então o processo passa pelo nó 'CONFIG-TEST'
-    Entao o processo para no nó 'NOTIFY-TEST'
-    Quando o usuário submete '{}'
+    Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
+    Quando o usuário submete '{ "token": {{token}} }'
     Entao o processo passou pelo menos 2 vezes pelo nó 'COUNT-TEST'
     Entao o processo passou 3 vezes pelo nó 'CHECK-COUNT-TEST' 
-    Entao o processo finaliza no nó 'END-TEST'
+    Entao o processo finaliza no nó 'END-TEST-SUCCESS'  
+    
+  @unhappy
+  Cenario: test unhappy path
+    Dado que um usuario anonimo esta logado
+    Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais ''
+    Então o processo passa pelo nó 'CONFIG-TEST'
+    Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
+    Quando o usuário submete '{ "token": "123" }'
+    Entao o processo passou pelo menos 2 vezes pelo nó 'COUNT-TEST'
+    Entao o processo passou 3 vezes pelo nó 'CHECK-COUNT-TEST' 
+    Entao o processo finaliza no nó 'END-TEST-ERROR'

--- a/tests/features/testBlueprint.feature
+++ b/tests/features/testBlueprint.feature
@@ -4,7 +4,7 @@ Funcionalidade: testBlueprint
   @happy
   Cenario: test happy path
     Dado que um usuario anonimo esta logado
-    Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais ''
+    Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais '{}'
     Então o processo passa pelo nó 'CONFIG-TEST'
     Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
     Quando o usuário submete '{ "token": {{token}} }'
@@ -15,7 +15,7 @@ Funcionalidade: testBlueprint
   @unhappy
   Cenario: test unhappy path
     Dado que um usuario anonimo esta logado
-    Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais ''
+    Dado que um processo de 'testBlueprint' foi iniciado com os dados iniciais '{}'
     Então o processo passa pelo nó 'CONFIG-TEST'
     Entao o processo para no nó 'CONFIRM-TOKEN-TEST'
     Quando o usuário submete '{ "token": "123" }'


### PR DESCRIPTION
Adição da dependência do mustache;
Alteração da BP de testes para abranger o novo step do cucumber;
Adição da função wait no arquivo de steps (para não ficar no método getProcessHistory e evitar possíveis erros);
Alteração do arquivo de testes da BP de teste;
Alteração do step 'submitActivity' para simular o submite de valor da bag quando há valores entre duas chaves no payload;
OBS: não achei necessário adicionar um step que verifica se "guarda" o valor na bag, pois é possível buscar diretamente da bag do histórico do processo, e já criei em outra branch o step pra verificar se um nó possui um valor na bag/result. Mas se achar necessário posso adicionar esse step.
OBS 2: Tive de incluir dois métodos de Object (guardando os pares key/value em um array e retornando novamente para um objeto com todos valores em string) pois o método mustache.render() puxa o valor do objeto como um número (caso seja valor numérico) e dá erro no submit (que normalmente espera string).